### PR TITLE
require Compat (since we're using it)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 MathOptInterface 0.3
 MacroTools
 FunctionWrappers 0.1.0
+Compat 0.33


### PR DESCRIPTION
I'm guessing about the lower bound, but we at least need to REQUIRE it