### PR TITLE
Convert constraint expressions to Vector{<:AffineFunction}

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -84,9 +84,10 @@ addconstraint!(m::Model{T}, c::Constraint{T, MOI.Nonpositives}) where {T} = push
 addconstraint!(m::Model{T}, c::Constraint{T, MOI.Zeros}) where {T} = push!(m.zeroconstraints, c)
 
 function addconstraint!(m::Model{T}, f, set::MOI.AbstractVectorSet) where T
+    f′ = @expression convert(Vector{AffineFunction{T}}, f) # to handle e.g. constraint functions that return SVectors
     m.initialized && error()
-    constraint = Constraint{T}(f, set)
-    constraint.modelindex = MOI.addconstraint!(m.backend, MOI.VectorAffineFunction(f()), set)
+    constraint = Constraint{T}(f′, set)
+    constraint.modelindex = MOI.addconstraint!(m.backend, MOI.VectorAffineFunction(f′()), set)
     addconstraint!(m, constraint)
     nothing
 end

--- a/src/parameter.jl
+++ b/src/parameter.jl
@@ -16,7 +16,7 @@ Parameter(f, model) = Parameter{typeof(f())}(f, model)
 isinplace(::Type{Parameter{T, F, InPlace}}) where {T, F, InPlace} = InPlace
 Base.show(io::IO, param::Parameter{T, F, InPlace}) where {T, F, InPlace} = print(io, "Parameter{$T, …}(…)")
 
-function (parameter::Parameter{T})() where {T}
+@inline function (parameter::Parameter{T})() where {T}
     if parameter.dirty[]
         update!(parameter)
         parameter.dirty[] = false

--- a/test/lazyexpression.jl
+++ b/test/lazyexpression.jl
@@ -202,4 +202,18 @@ end
     @test (@expression vcat(x', [1, 2, 3, 4]'))() == vcat(x', [1, 2, 3, 4]')
 end
 
+@testset "convert optimization" begin
+    m = MockModel()
+    A = Parameter{SMatrix{3, 3, Int, 9}}(m) do
+        @SMatrix ones(Int, 3, 3)
+    end
+    x = Variable.(1 : 3)
+    expr = @expression convert(Vector, A * x)
+
+    @test expr() == A() * x
+    @test expr() isa Vector{AffineFunction{Int}}
+    allocs = @allocated expr()
+    @test allocs == 0
+end
+
 end


### PR DESCRIPTION
To improve support for `SVector`s. Also add optimization for convert. Also force-inline `evalarg`.