### PR TITLE
specialize printing and argument recursion for wrapped expressions

### DIFF
--- a/src/debug.jl
+++ b/src/debug.jl
@@ -1,3 +1,6 @@
+_debug_args(expr::LazyExpression) = expr.args
+_debug_args(expr::LazyExpression{<:FunctionWrapper}) = expr.f.obj[].args
+
 function findallocs(io::IO, x, depth = 0, argnum = nothing)
     depth > 0 && print(io, "  "^depth)
     argnum != nothing && print(io, "[$argnum]: ")
@@ -13,7 +16,7 @@ function findallocs(io::IO, x, depth = 0, argnum = nothing)
         println(io, typeof(x))
     end
     if x isa LazyExpression
-        for (argnum, arg) in enumerate(x.args)
+        for (argnum, arg) in enumerate(_debug_args(x))
             findallocs(io, arg, depth + 1, argnum)
         end
     end

--- a/src/lazyexpression.jl
+++ b/src/lazyexpression.jl
@@ -5,6 +5,9 @@ struct LazyExpression{F, A}
 end
 
 Base.show(io::IO, expr::LazyExpression{F}) where {F} = print(io, "LazyExpression{$F, …}(…)")
+function Base.show(io::IO, expr::LazyExpression{F}) where {F <: FunctionWrapper}
+    print(io, "LazyExpression{FunctionWrapper{…}($(expr.f.obj[]))}(…)")
+end
 
 
 # Evaluation


### PR DESCRIPTION
Fixes #33 

Before: 

```julia
julia> SimpleQP.findallocs(@expression (zeros(2, 2) * zeros(2)) + 1)
LazyExpression{FunctionWrappers.FunctionWrapper{Array{Float64,1},Tuple{}}, …}(…): 192 bytes
```

After: 

```julia
julia> SimpleQP.findallocs(@expression (zeros(2, 2) * zeros(2)) + 1)
LazyExpression{FunctionWrapper{…}(LazyExpression{Base.#+, …}(…))}(…): 192 bytes
  [1]: LazyExpression{FunctionWrapper{…}(LazyExpression{Base.#*, …}(…))}(…): 96 bytes
    [1]: LazyExpression{FunctionWrapper{…}(LazyExpression{Base.#identity, …}(…))}(…): 0 bytes
      [1]: Array{Float64,2}
    [2]: LazyExpression{FunctionWrapper{…}(LazyExpression{Base.#identity, …}(…))}(…): 0 bytes
      [1]: Array{Float64,1}
  [2]: Int64
```