### PR TITLE
more optimizations

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -502,6 +502,49 @@ function Base.:*(A::StridedMatrix{T}, x::StridedVector{Variable}) where {T<:Line
     matvecmul!(similar(x, AffineFunction{T}, size(A, 1)) , A, x)
 end
 
+function scale!(
+    dest::AbstractVector{<:LinearTerm},
+    x::Number,
+    y::AbstractVector{Variable})
+    @boundscheck indices(dest) == indices(y) || throw(DimensionMismatch())
+    @inbounds for i in eachindex(dest)
+        dest[i] = x * y[i]
+    end
+    dest
+end
+
+function scale!(
+    dest::AbstractVector{<:LinearTerm},
+    x::AbstractVector{Variable},
+    y::Number)
+    @boundscheck indices(dest) == indices(y) || throw(DimensionMismatch())
+    @inbounds for i in eachindex(dest)
+        dest[i] = x[i] * y
+    end
+    dest
+end
+
+function scale!(
+    dest::AbstractVector{<:AffineFunction},
+    x::Number,
+    y::AbstractVector{<:AffineFunction})
+    @boundscheck indices(dest) == indices(y) || throw(DimensionMismatch())
+    @inbounds for i in eachindex(dest)
+        mul!(dest[i], x, y[i])
+    end
+    dest
+end
+
+function scale!(
+    dest::AbstractVector{<:AffineFunction},
+    x::AbstractVector{<:AffineFunction},
+    y::Number)
+    @boundscheck indices(dest) == indices(y) || throw(DimensionMismatch())
+    @inbounds for i in eachindex(dest)
+        mul!(dest[i], x[i], y)
+    end
+    dest
+end
 
 if VERSION >= v"0.7-"
     error("TODO: implement mul! for 0.7")

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -517,7 +517,7 @@ function scale!(
     dest::AbstractVector{<:LinearTerm},
     x::AbstractVector{Variable},
     y::Number)
-    @boundscheck indices(dest) == indices(y) || throw(DimensionMismatch())
+    @boundscheck indices(dest) == indices(x) || throw(DimensionMismatch())
     @inbounds for i in eachindex(dest)
         dest[i] = x[i] * y
     end
@@ -539,7 +539,7 @@ function scale!(
     dest::AbstractVector{<:AffineFunction},
     x::AbstractVector{<:AffineFunction},
     y::Number)
-    @boundscheck indices(dest) == indices(y) || throw(DimensionMismatch())
+    @boundscheck indices(dest) == indices(x) || throw(DimensionMismatch())
     @inbounds for i in eachindex(dest)
         mul!(dest[i], x[i], y)
     end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -453,6 +453,31 @@ function matvecmul!(
     y
 end
 
+function matvecmul!(
+    y::AbstractVector{AffineFunction{T}},
+    A::AbstractMatrix{<:Number},
+    x::AbstractVector{<:AffineFunction}) where T
+    rows, cols = size(A)
+    @boundscheck length(y) == rows || throw(DimensionMismatch())
+    @boundscheck length(x) == cols || throw(DimensionMismatch())
+    @inbounds for row in eachindex(y)
+        if isassigned(y, row)
+            zero!(y[row])
+        else
+            y[row] = zero(AffineFunction{T})
+        end
+    end
+    i = 1
+    @inbounds for col in Base.OneTo(cols)
+        for row in Base.OneTo(rows)
+            muladd!(y[row], A[i], x[col])
+            i += 1
+        end
+    end
+    y
+end
+
+
 function bilinearmul!(
         dest::QuadraticFunction,
         Q::AbstractMatrix,

--- a/src/lazyexpression.jl
+++ b/src/lazyexpression.jl
@@ -139,12 +139,11 @@ function optimize(expr::LazyExpression{typeof(convert)}, ::Type, ::Type{<:Abstra
 end
 
 function optimize(expr::LazyExpression{typeof(*)}, ::Type{<:Number}, ::Type{<:AbstractVector{<:Union{Variable, AffineFunction}}})
-    LazyExpression(deepcopy(expr()), expr.args...) do dest, x, y
-        for I in eachindex(dest)
-            Functions.mul!(dest[I], x, y[I])
-        end
-        dest
-    end
+    LazyExpression(Functions.scale!, deepcopy(expr()), expr.args...)
+end
+
+function optimize(expr::LazyExpression{typeof(*)}, ::Type{<:AbstractVector{<:Union{Variable, AffineFunction}}}, ::Type{<:Number})
+    LazyExpression(Functions.scale!, deepcopy(expr()), expr.args...)
 end
 
 # Wrapping

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -125,6 +125,13 @@ end
     @test y == fill(sum(x), size(A, 1))
     allocs = @allocated Functions.matvecmul!(y, A, x)
     @test allocs == 0
+
+    Bx = rand(4, 4) * x
+    y2 = Vector{AffineFunction{Float64}}(undef, size(A, 1))
+    Functions.matvecmul!(y2, A, Bx)
+    @test y2 == fill(sum(Bx), size(A, 1))
+    allocs = @allocated Functions.matvecmul!(y2, A, Bx)
+    @test allocs == 0
 end
 
 @testset "mul!" begin

--- a/test/lazyexpression.jl
+++ b/test/lazyexpression.jl
@@ -144,12 +144,16 @@ end
     @test allocs == 0
 end
 
-@testset "scalar-vector product optimization" begin
+@testset "scale! optimization" begin
     x = Variable.(1 : 3)
     dt = 0.01
     @testset "Variable" begin
         expr = @expression dt * x
         @test expr() == dt * x
+        @test @allocated(expr()) == 0
+
+        expr = @expression x * dt
+        @test expr() == x * dt
         @test @allocated(expr()) == 0
     end
 
@@ -157,6 +161,10 @@ end
         Ax = ones(3, 3) * x
         expr = @expression dt * Ax
         @test expr() == dt * Ax
+        @test @allocated(expr()) == 0
+
+        expr = @expression Ax * dt
+        @test expr() == Ax * dt
         @test @allocated(expr()) == 0
     end
 end

--- a/test/lazyexpression.jl
+++ b/test/lazyexpression.jl
@@ -144,6 +144,24 @@ end
     @test allocs == 0
 end
 
+@testset "scalar-vector product optimization" begin
+    x = Variable.(1 : 3)
+    dt = 0.01
+    @testset "Variable" begin
+        expr = @expression dt * x
+        @test expr() == dt * x
+        @test @allocated(expr()) == 0
+    end
+
+    @testset "AffineFunction" begin
+        Ax = ones(3, 3) * x
+        expr = @expression dt * Ax
+        @test expr() == dt * Ax
+        @test @allocated(expr()) == 0
+    end
+end
+
+
 @testset "vcat optimization" begin
     srand(42)
     m = MockModel()
@@ -230,6 +248,25 @@ end
     expr1 = @expression transpose(x) * eye(Int, n) * x + q' * x
     expr2 = @expression q' * x + transpose(x) * eye(Int, 2) * x
     @test expr1() == expr2()
+end
+
+@testset "issue 32" begin
+    model = MockModel()
+    v = [Variable(model) for _ in 1:2]
+    v0 = zeros(2)
+    Δt = 0.01
+    u = [Variable(model) for _ in 1:2]
+    H = Parameter(zeros(2, 2), model) do H
+        H[1, 1] = rand()
+        H[2, 2] = rand()
+    end
+    c = Parameter(zeros(2), model) do c
+        c[1] = rand()
+        c[2] = rand()
+    end
+    expr = @expression(H * (v - v0) - Δt * (u - c))
+    @test expr() == H() * (v - v0) - Δt * (u - c())
+    @test @allocated(expr()) == 0
 end
 
 end

--- a/test/lazyexpression.jl
+++ b/test/lazyexpression.jl
@@ -145,26 +145,29 @@ end
 end
 
 @testset "scale! optimization" begin
-    x = Variable.(1 : 3)
-    dt = 0.01
+    model = MockModel()
+    x = [Variable(model) for _ in 1 : 3]
+    dt = Parameter{Float64}(model) do
+        2.0
+    end
     @testset "Variable" begin
         expr = @expression dt * x
-        @test expr() == dt * x
+        @test expr() == dt() * x
         @test @allocated(expr()) == 0
 
         expr = @expression x * dt
-        @test expr() == x * dt
+        @test expr() == x * dt()
         @test @allocated(expr()) == 0
     end
 
     @testset "AffineFunction" begin
         Ax = ones(3, 3) * x
         expr = @expression dt * Ax
-        @test expr() == dt * Ax
+        @test expr() == dt() * Ax
         @test @allocated(expr()) == 0
 
         expr = @expression Ax * dt
-        @test expr() == Ax * dt
+        @test expr() == Ax * dt()
         @test @allocated(expr()) == 0
     end
 end


### PR DESCRIPTION
Optimize `AbstractMatrix{<:Number} * AbstractVector{<:AffineFunction}` and `<:Number * AbstractVector{<:Union{Variable, AffineFunction}}`. Fixes #32 

I implemented the optimization for Number*Vector with an anonymous function, but I assume that's not what we'll actually want. Should there be a new method of `mul!(::AbstractVector)`? Or a new `vecmul!`? Or we could even get really fancy and make a `Foreach!` wrapper type that does the broadcasting. 