### PR TITLE
rewrite `@expression` macro to allow $-interpolation

### DIFF
--- a/src/lazyexpression.jl
+++ b/src/lazyexpression.jl
@@ -24,29 +24,36 @@ end
     end
 end
 
+lazy_wrap(x) = esc(x)
 
-# expression macro
-macro expression(expr)
-    # We call expand(expr) to lower the code and make some useful conversions like:
-    #   * [x; y] turns from Expr(:vcat, :x, :y) into Expr(:call, :vcat, :x, :y)
-    #   * x .+ y turns from Expr(:call, :.+, :x, :y) into Expr(:call, :broadcast, :+, :x, :y) (on v0.6)
-    postwalk(expand(expr)) do x
-        if @capture(x, f_(args__))
-            :(wrap(SimpleQP.optimize_toplevel(SimpleQP.LazyExpression($f, $(args...)))))
+function lazy_wrap(x::Expr)
+    if x.head == :line
+        return esc(x)
+    elseif x.head == :$ && length(x.args) == 1
+        return esc(x.args[1])
+    elseif x.head == :block
+        return esc(Expr(x.head, lazy_wrap.(x.args)...))
+    elseif x.head == :call
+        if x.args[1] == GlobalRef(Core, :getfield)  # TODO: probably different on 0.7
+            return esc(x)
         else
-            if x isa Expr && x.head ∉ [:block, :line]
-                buf = IOBuffer()
-                dump(buf, expr)
-                msg =
-                    """
-                    Unhandled expression head: $(x.head). expr:
-                    $(String(take!(buf)))
-                    """
-                return :(throw(ArgumentError($msg)))
-            end
-            esc(x)
+            return :(wrap(SimpleQP.optimize_toplevel(SimpleQP.LazyExpression($(lazy_wrap.(x.args)...)))))
         end
+    else
+        buf = IOBuffer()
+        dump(buf, x)
+        msg =
+            """
+            Unhandled expression head: $(x.head). expr:
+            $(String(take!(buf)))
+            """
+        return :(throw(ArgumentError($msg)))
     end
+end
+
+
+macro expression(expr)
+    lazy_wrap(expand(expr))
 end
 
 

--- a/src/lazyexpression.jl
+++ b/src/lazyexpression.jl
@@ -32,7 +32,7 @@ function lazy_wrap(x::Expr)
     elseif x.head == :$ && length(x.args) == 1
         return esc(x.args[1])
     elseif x.head == :block
-        return esc(Expr(x.head, lazy_wrap.(x.args)...))
+        return Expr(x.head, lazy_wrap.(x.args)...)
     elseif x.head == :call
         if x.args[1] == GlobalRef(Core, :getfield)  # TODO: probably different on 0.7
             return esc(x)

--- a/test/lazyexpression.jl
+++ b/test/lazyexpression.jl
@@ -24,9 +24,9 @@ end
         2 + 2
     end
     wrapped = SimpleQP.lazy_wrap(expr)
-    @test wrapped == esc(Expr(
+    @test wrapped == Expr(
         expr.head,
-        SimpleQP.lazy_wrap.(expr.args)...))
+        SimpleQP.lazy_wrap.(expr.args)...)
 end
 
 @testset "parameter" begin

--- a/test/lazyexpression.jl
+++ b/test/lazyexpression.jl
@@ -5,7 +5,7 @@ using Compat.Test
 using SimpleQP
 using StaticArrays
 
-import SimpleQP: setdirty!, MockModel
+using SimpleQP: setdirty!, MockModel, _debug_args, LazyExpression
 
 @testset "basics" begin
     a = 2
@@ -230,6 +230,47 @@ end
     expr1 = @expression transpose(x) * eye(Int, n) * x + q' * x
     expr2 = @expression q' * x + transpose(x) * eye(Int, 2) * x
     @test expr1() == expr2()
+end
+
+@testset "Fully-qualified names" begin
+    expr = @expression Base.:+(2, 2)
+    @test expr() == 4
+    @test @allocated(expr()) == 0
+
+    expr = @expression Base.:+(Base.:*(1, 2), 4 + 5)
+    @test expr() == 11
+    @test @allocated(expr()) == 0
+end
+
+@testset "Interpolated arguments" begin
+    e1 = @expression 1 + 2 * (3 * 4 + (5 * 6))
+    @test _debug_args(e1)[1] == 1
+    @test _debug_args(e1)[2] isa LazyExpression
+    @test _debug_args(_debug_args(e1)[2])[1] == 2
+    @test _debug_args(_debug_args(e1)[2])[2] isa LazyExpression
+
+    e2 = @expression 1 + 2 * $(3 * 4 + (5 * 6))
+    @test _debug_args(e2)[1] == 1
+    @test _debug_args(e2)[2] isa LazyExpression
+    @test _debug_args(_debug_args(e2)[2]) == (84,)
+end
+
+end
+
+module HygieneTest
+
+# Verify that we're not accidentally escaping things that should
+# still be evaluated inside SimpleQP. We can check that by trying
+# to construct an expression in a scope which *only* has the
+# @expression macro available. Any accidental escaping of SimpleQP
+# functions will cause undefined variable errors.
+
+using SimpleQP: @expression
+using Base.Test
+
+@testset "Basic @expression" begin
+    expr = @expression 2 + 2
+    @test expr() == 4
 end
 
 end

--- a/test/lazyexpression.jl
+++ b/test/lazyexpression.jl
@@ -19,6 +19,16 @@ end
     @test_throws(ArgumentError, @expression x ? y : z)
 end
 
+@testset "other expression heads" begin
+    expr = quote
+        2 + 2
+    end
+    wrapped = SimpleQP.lazy_wrap(expr)
+    @test wrapped == esc(Expr(
+        expr.head,
+        SimpleQP.lazy_wrap.(expr.args)...))
+end
+
 @testset "parameter" begin
     model = MockModel()
     a = 3


### PR DESCRIPTION
Fixes #30. Also fixes #23 (I think). 