### PR TITLE
Improve greedy evaluation.

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -155,7 +155,9 @@ Base.hash(x::QuadraticFunction, h::UInt) = (h = hash(x.quadratic, h); hash(x.aff
 Base.zero(::Type{QuadraticFunction{T}}) where {T} = QuadraticFunction(QuadraticTerm{T}[], zero(AffineFunction{T}))
 zero!(f::QuadraticFunction) = (empty!(f.quadratic); zero!(f.affine); f)
 
-# TODO: conversions
+Base.convert(::Type{QuadraticFunction{T}}, x::QuadraticTerm) where {T} =
+    QuadraticFunction([convert(QuadraticTerm{T}, x)], zero(AffineFunction{T}))
+
 
 function Base.show(io::IO, f::QuadraticFunction)
     for term in f.quadratic


### PR DESCRIPTION
Fixes the issue I noted in https://github.com/tkoolen/SimpleQP.jl/pull/37#pullrequestreview-132220452.

I opted to not try to fix `optimizearg`, but instead to simply get rid of it, and to allow `@expression` to return a *value* (instead of always returning a LazyExpression), if none of the arguments of the LazyExpression are parameters or other LazyExpressions.

To support this, I added a `convert`-to-`WrappedExpression` method that takes a value, and used it in the Objective and Constraint constructors.

This also fixes the broken allocation test case.

@rdeits, I added two test cases that ensure that you can actually do what you wanted in #30 *without* the interpolation stuff. Do you think this is sufficient for your needs?