### PR TITLE
optimize 1-argument vect()

### DIFF
--- a/src/lazyexpression.jl
+++ b/src/lazyexpression.jl
@@ -159,3 +159,11 @@ end
 function optimize(expr::LazyExpression{typeof(*)}, ::Type{<:AbstractVector{<:Union{Variable, AffineFunction}}}, ::Type{<:Number})
     LazyExpression(Functions.scale!, deepcopy(expr()), expr.args...)
 end
+
+function optimize(expr::LazyExpression{typeof(Base.vect)}, ::Type{<:Union{Variable, LinearTerm, AffineFunction}})
+    LazyExpression(deepcopy(expr()), expr.args...) do dest, x
+        @boundscheck size(dest) == (1,) || throw(DimensionMismatch())
+        dest[1] = x
+        dest
+    end
+end

--- a/test/lazyexpression.jl
+++ b/test/lazyexpression.jl
@@ -233,6 +233,17 @@ end
     @test (@expression vcat(f1, 3))() == vcat(f1(), 3)
 end
 
+@testset "vect optimization" begin
+    m = MockModel()
+    x = Variable.(1:2)
+    p = Parameter(m) do
+        SVector(1., 2.)
+    end
+    expr = @expression [dot(p, x)]
+    @test expr() == [dot(p(), x)]
+    @test @allocated(expr()) == 0
+end
+
 @testset "convert optimization" begin
     m = MockModel()
     A = Parameter{SMatrix{3, 3, Int, 9}}(m) do


### PR DESCRIPTION
Partial work-around for #35 

With this PR, we can do things like `@constraint model [x] == [0]` for some scalar affine expression x with no allocation