### PR TITLE
Support for integer/binary constraints.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 julia:
   - 0.6
-  - 0.7
+  # - 0.7
   - nightly
 branches:
   only:

--- a/src/moi_interop.jl
+++ b/src/moi_interop.jl
@@ -1,10 +1,10 @@
 # TODO: Scalar constraints
 MOIU.@model(SimpleQPMOIModel, # modelname
-    (), # scalarsets
+    (ZeroOne, Integer), # scalarsets
     (), # typedscalarsets
     (Zeros, Nonnegatives, Nonpositives), # vectorsets
     (), # typedvectorsets
-    (), # scalarfunctions
+    (SingleVariable,), # scalarfunctions
     (), # typedscalarfunctions
     (), # vectorfunctions
     (VectorAffineFunction,) # typedvectorfunctions

--- a/test/model.jl
+++ b/test/model.jl
@@ -217,4 +217,36 @@ end
     end
 end
 
+if !parse(Bool, get(ENV, "CI", "false"))
+    using Gurobi
+    @testset "integer basics" begin
+        optimizer = GurobiOptimizer(OutputFlag=0)
+        model = Model(optimizer)
+        x = Variable(model)
+        @constraint model x ∈ ℤ
+        @constraint model [x] >= [0.5]
+        @objective model Minimize x
+
+        solve!(model)
+
+        @test terminationstatus(model) == MOI.Success
+        @test primalstatus(model) == MOI.FeasiblePoint
+        @test value(model, x) ≈ 1.0 atol=1e-8
+    end
+
+    @testset "boolean basics" begin
+        optimizer = GurobiOptimizer(OutputFlag=0)
+        model = Model(optimizer)
+        x = Variable(model)
+        @constraint model x ∈ {0, 1}
+        @objective model Maximize x
+
+        solve!(model)
+
+        @test terminationstatus(model) == MOI.Success
+        @test primalstatus(model) == MOI.FeasiblePoint
+        @test value(model, x) ≈ 1.0 atol=1e-8
+    end
+end
+
 end # module


### PR DESCRIPTION
Update constraint macro to handle integrality and boolean constraints. Add basic integer/boolean tests.

Also rename `Constraint` -> `VectorConstraint` for clarity.

@rdeits, I think this should cover basic usage; any comments? Is the macro syntax OK?

I'm not sure yet about whether/how to store constraint references for these constraints. Thoughts?