### PR TITLE
Fixes for 0.7 and a Parameter convenience method

### DIFF
--- a/src/SimpleQP.jl
+++ b/src/SimpleQP.jl
@@ -1,4 +1,4 @@
-__precompile__()
+VERSION < v"0.7.0-beta2.199" && __precompile__()
 
 module SimpleQP
 

--- a/src/lazyexpression.jl
+++ b/src/lazyexpression.jl
@@ -150,8 +150,12 @@ macro expression(expr)
                     return :(Base.getproperty($(x.args...)))
                 elseif x.head == :vcat
                     return :(Base.vcat($(x.args...)))
+                elseif x.head == :hcat
+                    return :(Base.hcat($(x.args...)))
                 elseif x.head == :vect
                     return :(Base.vect($(x.args...)))
+                elseif x.head == :ref
+                    return :(Base.getindex($(x.args...)))
                 elseif x.head == Symbol("'")
                     return :(Compat.adjoint($(x.args...)))
                 end

--- a/test/lazyexpression.jl
+++ b/test/lazyexpression.jl
@@ -362,8 +362,7 @@ function allocations_in_local_scope(x)
 end
 
 @testset "getfield optimization" begin
-    m = MockModel()
-    model = SimpleQP.MockModel()
+    model = MockModel()
     p = Parameter(model) do
         MyWrapper(rand())
     end
@@ -380,6 +379,28 @@ end
     @test ex2() == p().x + 1
     setdirty!(p)
     @test allocations_in_local_scope(ex2) == 0
+end
+
+@testset "hcat" begin
+    model = MockModel()
+    p = Parameter(model) do
+        rand(3, 3)
+    end
+    hcat_expr = @expression [p p]
+    @test hcat_expr() == [p() p()]
+    setdirty!(p)
+    @test hcat_expr() == [p() p()]
+end
+
+@testset "getindex" begin
+    model = MockModel()
+    p = Parameter(model) do
+        rand(3, 3)
+    end
+    getindex_expr = @expression p[:,2]
+    @test getindex_expr() == p()[:,2]
+    setdirty!(p)
+    @test getindex_expr() == p()[:,2]
 end
 
 end


### PR DESCRIPTION
Hey RLGers, thanks for putting this package together - defining SimpleQP models is certainly way better than stuffing OSQP problems by hand! These are just a few small changes (see the commit messages) I've found useful while using SimpleQP on julia 0.7. No optimizations yet for `hcat` and `getindex`, but this PR at least achieves feature parity with 0.6 and is useful for manipulating arrays of `Variable`s if nothing else.

P.S. I'll probably end up citing this package in the next month or two so if you make a decision on #38 sooner than later it might help with URL longevity.