### PR TITLE
[WIP] Change - to .- to avoid deprecation warning

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -230,11 +230,11 @@ macro constraint(model, expr)
     lhs = expr.args[2]
     rhs = expr.args[3]
     if relation == :(>=)
-        ret = :(SimpleQP.add_nonnegative_constraint!($model, SimpleQP.@expression $lhs - $rhs))
+        ret = :(SimpleQP.add_nonnegative_constraint!($model, SimpleQP.@expression broadcast(-, $lhs, $rhs)))
     elseif relation == :(<=)
-        ret = :(SimpleQP.add_nonpositive_constraint!($model, SimpleQP.@expression $lhs - $rhs))
+        ret = :(SimpleQP.add_nonpositive_constraint!($model, SimpleQP.@expression broadcast(-, $lhs, $rhs)))
     elseif relation == :(==)
-        ret = :(SimpleQP.add_zero_constraint!($model, SimpleQP.@expression $lhs - $rhs))
+        ret = :(SimpleQP.add_zero_constraint!($model, SimpleQP.@expression broadcast(-, $lhs, $rhs)))
     elseif relation ∈ [:∈, :in]
         if rhs ∈ [:ℤ, :Integers]
             ret = :(SimpleQP.add_integer_constraint!($model, $lhs))


### PR DESCRIPTION
This change avoids warnings of the form
```
┌ Warning: `a::AbstractArray - b::Number` is deprecated, use `a .- b` instead.
│   caller = optimize_toplevel at lazyexpression.jl:59 [inlined]
└ @ Core ~/.julia/packages/SimpleQP/pHx4o/src/lazyexpression.jl:59
```
when defining constraints like `@constraint(m, v >= 0)` for `Vector`-valued `v`.