### PR TITLE
Fixes and CI for 0.7/1.0. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,24 @@
-## Documentation: http://docs.travis-ci.com/user/languages/julia/
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
 os:
   - linux
   - osx
 julia:
   - 0.6
-  # - 0.7
+  - 0.7
+  - 1.0
   - nightly
+matrix:
+  allow_failures:
+  - julia: nightly
+  - julia: 1.0
 branches:
   only:
     - master
     - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags
 notifications:
   email: false
-git:
-  depth: 99999999
-matrix:
- allow_failures:
- - julia: nightly
 before_script:
   - julia -e 'if VERSION >= v"0.7-"; import Pkg; repo = Pkg.Types.GitRepo("https://github.com/tkoolen/FunctionWrappers.jl", "tk/julia-0.7"); Pkg.add(Pkg.Types.PackageSpec(repo)); end'
-## uncomment the following lines to override the default test script
-#script:
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Parametron"); Pkg.test("Parametron"; coverage=true)'
 after_success:
-  # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("Parametron")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("Parametron")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+- if [[ "$TRAVIS_JULIA_VERSION" == 0.6 ]]; then julia -e 'cd(Pkg.dir("Parametron")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'; else julia --project -e 'Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'; fi

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-MathOptInterface 0.4
+MathOptInterface 0.4 0.5 # because of copy! return value change
 MacroTools
 FunctionWrappers 0.1.0
 Compat 0.33

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,4 @@
 OSQP 0.1.8
 StaticArrays 0.7
 Gurobi
+GLPK

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,3 @@
 OSQP 0.1.8
 StaticArrays 0.7
-GLPK
 Gurobi

--- a/test/lazyexpression.jl
+++ b/test/lazyexpression.jl
@@ -7,6 +7,12 @@ using Compat.LinearAlgebra
 using Parametron
 using StaticArrays
 
+if VERSION < v"0.7.0-DEV.3406"
+    const seed! = srand
+else
+    using Random: seed!
+end
+
 import Parametron: setdirty!, MockModel
 
 @testset "basics" begin
@@ -186,7 +192,7 @@ end
 
 
 @testset "vcat optimization" begin
-    srand(42)
+    seed!(42)
     m = MockModel()
     A = Parameter(rand!, zeros(3, 4), m)
     B = Parameter(rand!, zeros(3, 3), m)

--- a/test/model.jl
+++ b/test/model.jl
@@ -6,7 +6,6 @@ using Compat.Random
 using Compat.LinearAlgebra
 using Parametron
 using OSQP.MathOptInterfaceOSQP
-using GLPK
 using StaticArrays: SVector
 
 import MathOptInterface
@@ -219,22 +218,23 @@ end
     end
 end
 
-@testset "boolean basics" begin
-    optimizer = GLPKOptimizerMIP()
-    model = Model(optimizer)
-    x = Variable(model)
-    @constraint model x ∈ {0, 1}
-    @objective model Maximize x
-
-    solve!(model)
-
-    @test terminationstatus(model) == MOI.Success
-    @test primalstatus(model) == MOI.FeasiblePoint
-    @test value(model, x) ≈ 1.0 atol=1e-8
-end
-
 if !parse(Bool, get(ENV, "CI", "false"))
     using Gurobi
+
+    @testset "boolean basics" begin
+        optimizer = GurobiOptimizer(OutputFlag=0)
+        model = Model(optimizer)
+        x = Variable(model)
+        @constraint model x ∈ {0, 1}
+        @objective model Maximize x
+
+        solve!(model)
+
+        @test terminationstatus(model) == MOI.Success
+        @test primalstatus(model) == MOI.FeasiblePoint
+        @test value(model, x) ≈ 1.0 atol=1e-8
+    end
+
     @testset "integer basics" begin
         optimizer = GurobiOptimizer(OutputFlag=0)
         model = Model(optimizer)


### PR DESCRIPTION
~~Also remove GLPK as a test dependency for now. Gurobi tests don't actually pass on 0.7 with latest released version of Gurobi, but they can't be tested on CI anyway.~~

Only use GLPK on 0.6 to at least get the test coverage.