### PR TITLE
Add test case for A' * x issue that fails on 0.6

### DIFF
--- a/test/lazyexpression.jl
+++ b/test/lazyexpression.jl
@@ -409,4 +409,14 @@ end
     @test getindex_expr() == p()[:,2]
 end
 
+@testset "A' * x (https://github.com/tkoolen/Parametron.jl/pull/79#issuecomment-423732633)" begin
+    model = MockModel()
+    n, m = 5, 15
+    Adata = randn(n, m)
+    A = Parameter(identity, Adata, model)
+    x = [Variable(model) for _ = 1:n]
+    resid = @expression A' * x
+    @test resid() == Adata' * x
+end
+
 end

--- a/test/model.jl
+++ b/test/model.jl
@@ -356,8 +356,8 @@ end
 end
 
 @testset "Parameter(A, model)" begin
-    rng = MersenneTwister(1)
     # From the README
+    rng = MersenneTwister(1)
     n, m = 5, 15
     Xdata = randn(n, m)
     pdata = Vector{Float64}(undef, m);


### PR DESCRIPTION
The implementation of stuff like `A' * x` has changed a lot between Julia 0.6 and 0.7/1.0. I can't justify spending the time to figure out how to properly support this type of expression in 0.6, so I'll be dropping support for 0.6 in the next PR.