### PR TITLE
Support higher-dimensional arrays in `dot`

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -617,8 +617,8 @@ Take the dot product of vectors `x` and `y`, storing the result in `dest`.
 function vecdot! end
 
 function _vecdot!(dest::AffineFunction,
-        x::AbstractVector{<:Union{Number, AffineFunction}},
-        y::AbstractVector{<:Union{Number, AffineFunction}})
+        x::AbstractArray{<:Union{Number, AffineFunction}},
+        y::AbstractArray{<:Union{Number, AffineFunction}})
     zero!(dest)
     @boundscheck axes(x) == axes(y) || throw(DimensionMismatch())
     @inbounds for i in eachindex(x)
@@ -628,10 +628,10 @@ function _vecdot!(dest::AffineFunction,
 end
 
 function _vecdot!(dest::AffineFunction,
-        x::AbstractVector{<:Union{Number, Variable, LinearTerm}},
-        y::AbstractVector{<:Union{Number, Variable, LinearTerm}})
+        x::AbstractArray{<:Union{Number, Variable, LinearTerm}},
+        y::AbstractArray{<:Union{Number, Variable, LinearTerm}})
     zero!(dest)
-    @boundscheck length(x) == length(y) || throw(DimensionMismatch())
+    @boundscheck axes(x) == axes(y) || throw(DimensionMismatch())
     linear = dest.linear
     resize!(linear, length(x))
     @inbounds for i in eachindex(x)
@@ -667,9 +667,9 @@ function vecdot!(dest, x, y)
     dot(x, y)
 end
 
-vecdot!(dest::AffineFunction, x::AbstractVector{<:Number}, y::AbstractVector{<:Union{Variable, LinearTerm, AffineFunction}}) =
+vecdot!(dest::AffineFunction, x::AbstractArray{<:Number}, y::AbstractArray{<:Union{Variable, LinearTerm, AffineFunction}}) =
     _vecdot!(dest, x, y)
-vecdot!(dest::AffineFunction, x::AbstractVector{<:Union{Variable, LinearTerm, AffineFunction}}, y::AbstractVector{<:Number}) =
+vecdot!(dest::AffineFunction, x::AbstractArray{<:Union{Variable, LinearTerm, AffineFunction}}, y::AbstractArray{<:Number}) =
     _vecdot!(dest, x, y)
 vecdot!(dest::QuadraticFunction, x::AbstractVector{<:Union{Variable, LinearTerm}}, y::AbstractVector{<:Union{Variable, LinearTerm}}) =
     _vecdot!(dest, x, y)

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -194,6 +194,13 @@ end
     end
 end
 
+@testset "dot with matrix variables" begin
+    inds = LinearIndices((1:2, 1:2))
+    x = [Variable(inds[i]) for i in CartesianIndices(inds)]
+    w = [0.1 0.2; 0.3 0.4]
+    @test x ⋅ w == w ⋅ x == 0.1 * x[1] + 0.3 * x[2] + 0.2 * x[3] + 0.4 * x[4] + 0.0
+end
+
 @testset "Matrix operations" begin
     x = Variable.(1 : 2)
     A1 = [1.0 2.0; 3.0 4.0]


### PR DESCRIPTION
I'm implementing the [earth mover distance](https://en.wikipedia.org/wiki/Earth_mover's_distance) and the most natural representation uses a matrix of `Variable`s and requires taking its dot-product with some weights.

Incidentally, in profiling I'm finding there's still quite a lot of allocation, which I'm guessing is a consequence of [this line](https://github.com/JuliaOpt/Gurobi.jl/blob/4a872c1ceed82df150558b62d968b09ab12fb18c/src/MOIWrapper.jl#L140). Any thoughts on how to get around it? Also [this line](https://github.com/JuliaOpt/Gurobi.jl/blob/4a872c1ceed82df150558b62d968b09ab12fb18c/src/grb_model.jl#L100) is insanely slow. Any tips for overcoming such problems?