### PR TITLE
Add canonicalize/canonicalize!

### DIFF
--- a/src/Parametron.jl
+++ b/src/Parametron.jl
@@ -48,6 +48,7 @@ const MOIU = MathOptInterface.Utilities
 
 @enum Sense Minimize Maximize
 
+include("util.jl")
 include("functions.jl")
 include("parameter.jl")
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -161,7 +161,6 @@ julia> term = 3 * y * x
 julia> canonicalize(term)
 3 * x1 * x2
 ```
-
 """
 function canonicalize(term::QuadraticTerm)
     QuadraticTerm(term.coeff, Variable.(minmax(term.rowvar.index, term.colvar.index))...)
@@ -198,7 +197,6 @@ julia> vals = Dict(x => 4, y => -3);
 julia> affinefun(vals)
 3
 ```
-
 """
 struct AffineFunction{T}
     linear::Vector{LinearTerm{T}}

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -268,8 +268,6 @@ sorted by variable index and with terms corresponding to the same variable combi
 julia> x, y = Variable.(1 : 2);
 
 julia> f = y + x - 2 * y + 3
-
-julia> f = y + x - 2 * y + 3
 1 * x2 + 1 * x1 + -2 * x2 + 3
 
 julia> canonicalize(f)
@@ -372,7 +370,7 @@ Return a canonicalized version of `f::QuadraticFunction`. See [`canonicalize(f::
 and [`canonicalize(f::AffineFunction)`](@ref) for more details. Quadratic terms are ordered lexicographically
 by `(term.rowvar, term.colvar)`.
 
-# Examples
+# Example
 
 ```julia
 julia> x, y = Variable.(1 : 2);

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -43,10 +43,31 @@ export
     AffineFunction,
     QuadraticFunction
 
+export
+    canonicalize,
+    canonicalize!
+
 using LinearAlgebra
 using DocStringExtensions
 
+using Parametron: sort_and_combine!
+
 coefftype(::Type{T}) where {T<:Number} = T
+
+
+"""
+$(SIGNATURES)
+
+Re-express a term or function in a canonical form.
+"""
+function canonicalize end
+
+"""
+$(SIGNATURES)
+
+In-place version of [`canonicalize`](@ref).
+"""
+function canonicalize! end
 
 # Variable
 
@@ -85,6 +106,11 @@ Base.:-(var::Variable) = LinearTerm(-1, var)
 Base.promote_rule(::Type{LinearTerm{T}}, ::Type{Variable}) where {T} = LinearTerm{T}
 Base.convert(::Type{LinearTerm{T}}, var::Variable) where {T} = LinearTerm{T}(var)
 
+function combine(t1::LinearTerm, t2::LinearTerm)
+    t1.var === t2.var || throw(ArgumentError())
+    LinearTerm(t1.coeff + t2.coeff, t1.var)
+end
+
 """
 $(TYPEDEF)
 
@@ -118,6 +144,36 @@ for Term in [:LinearTerm, :QuadraticTerm]
     end
 end
 
+"""
+$(SIGNATURES)
+
+Re-express the `QuadraticTerm` `term` so that the index of `term.rowvar` is
+less than or equal to that of `term.colvar`.
+
+# Example
+
+```julia
+julia> x, y = Variable.(1 : 2);
+
+julia> term = 3 * y * x
+3 * x2 * x1
+
+julia> canonicalize(term)
+3 * x1 * x2
+```
+
+"""
+function canonicalize(term::QuadraticTerm)
+    QuadraticTerm(term.coeff, Variable.(minmax(term.rowvar.index, term.colvar.index))...)
+end
+
+function combine(t1::QuadraticTerm, t2::QuadraticTerm)
+    t1 = canonicalize(t1)
+    t2 = canonicalize(t2)
+    t1.rowvar == t2.rowvar && t1.colvar == t2.colvar || throw(ArgumentError())
+    QuadraticTerm(t1.coeff + t2.coeff, t1.rowvar, t1.colvar)
+end
+
 
 # AffineFunction
 """
@@ -129,7 +185,7 @@ A scalar affine function represented by a sum of [`LinearTerm`](@ref)s and a con
 given values for the decision variables. The call operator takes an `AbstractDict{Variable, T}`
 collection, which associates values with variables.
 
-# Examples
+# Example
 
 ```julia
 julia> x, y = Variable.(1 : 2);
@@ -142,6 +198,7 @@ julia> vals = Dict(x => 4, y => -3);
 julia> affinefun(vals)
 3
 ```
+
 """
 struct AffineFunction{T}
     linear::Vector{LinearTerm{T}}
@@ -194,6 +251,32 @@ function (f::AffineFunction{T})(vals::AbstractDict{Variable, S}) where {T, S}
     ret
 end
 
+function canonicalize!(f::AffineFunction)
+    sort_and_combine!(f.linear; by=term -> term.var.index, combine=combine, alg=Base.Sort.QuickSort)
+    f
+end
+
+"""
+$(SIGNATURES)
+
+Return a canonicalized version of `f::AffineFunction`, namely with linear terms
+sorted by variable index and with terms corresponding to the same variable combined.
+
+# Example
+
+```julia
+julia> x, y = Variable.(1 : 2);
+
+julia> f = y + x - 2 * y + 3
+
+julia> f = y + x - 2 * y + 3
+1 * x2 + 1 * x1 + -2 * x2 + 3
+
+julia> canonicalize(f)
+1 * x1 + -1 * x2 + 3
+```
+"""
+canonicalize(f::AffineFunction) = canonicalize!(AffineFunction(f))
 
 # QuadraticFunction
 
@@ -274,6 +357,34 @@ function (f::QuadraticFunction{T})(vals::AbstractDict{Variable, S}) where {T, S}
     end
     ret
 end
+
+function canonicalize!(f::QuadraticFunction)
+    canonicalize!(f.affine)
+    canonicalized_variable_index_tuple = term -> (term = canonicalize(term); (term.rowvar.index, term.colvar.index))
+    sort_and_combine!(f.quadratic; by=canonicalized_variable_index_tuple, combine=combine, alg=Base.Sort.QuickSort)
+    f
+end
+
+"""
+$(SIGNATURES)
+
+Return a canonicalized version of `f::QuadraticFunction`. See [`canonicalize(f::QuadraticTerm)`](@ref)
+and [`canonicalize(f::AffineFunction)`](@ref) for more details. Quadratic terms are ordered lexicographically
+by `(term.rowvar, term.colvar)`.
+
+# Examples
+
+```julia
+julia> x, y = Variable.(1 : 2);
+
+julia> f = x * y + y * x + y + y + x - y
+1 * x1 * x2 + 1 * x2 * x1 + 1 * x2 + 1 * x2 + 1 * x1 + -1 * x2 + 0
+
+julia> canonicalize(f)
+2 * x1 * x2 + 1 * x1 + 1 * x2 + 0
+```
+"""
+canonicalize(f::QuadraticFunction) = canonicalize!(QuadraticFunction(f))
 
 
 # copyto!

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,0 +1,26 @@
+"""
+$(SIGNATURES)
+
+Sort the vector `v` in-place using `Base.sort!`, then combine all entries for which `by(v[i]) == by(v[j])`
+using the function `v[i] = combine(v[i], v[j])`. This may result in `v` being resized to a shorter length.
+
+See documentation for [`Base.sort!`](@ref) regarding the keyword arguments.
+"""
+function sort_and_combine!(v::AbstractVector;
+        alg::Base.Sort.Algorithm=Base.Sort.defalg(v), combine, by=identity, lt=isless, rev::Bool=false, order::Base.Ordering=Base.Order.Forward)
+    # For context, see: https://github.com/JuliaOpt/MathOptInterface.jl/issues/429#issuecomment-406232629.
+    isempty(v) && return v
+    sort!(v, alg=alg, lt=lt, by=by, rev=rev, order=order)
+    j = 1
+    @inbounds for i in eachindex(v)[2 : end]
+        x = v[i]
+        if lt(by(v[j]), by(x))
+            j += 1
+            v[j] = x
+        else
+            v[j] = combine(v[j], x)
+        end
+    end
+    resize!(v, j)
+    v
+end

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,16 +1,16 @@
 """
 $(SIGNATURES)
 
-Sort the vector `v` in-place using `Base.sort!`, then combine all entries for which `by(v[i]) == by(v[j])`
-using the function `v[i] = combine(v[i], v[j])`. This may result in `v` being resized to a shorter length.
+Sort the vector `v` in-place using `Base.sort!`, then combine all entries which compare equal
+(as determined using the `lt` and `by` functions), using the function `combined = combine(x, y)`.
 
-See documentation for [`Base.sort!`](@ref) regarding the keyword arguments.
+See documentation for [`Base.sort!`](@ref) regarding the `alg`, `by` and `lt` keyword arguments.
 """
 function sort_and_combine!(v::AbstractVector;
-        alg::Base.Sort.Algorithm=Base.Sort.defalg(v), combine, by=identity, lt=isless, rev::Bool=false, order::Base.Ordering=Base.Order.Forward)
+        alg::Base.Sort.Algorithm=Base.Sort.defalg(v), combine, by=identity, lt=isless)
     # For context, see: https://github.com/JuliaOpt/MathOptInterface.jl/issues/429#issuecomment-406232629.
     isempty(v) && return v
-    sort!(v, alg=alg, lt=lt, by=by, rev=rev, order=order)
+    sort!(v, alg=alg, lt=lt, by=by)
     j = 1
     @inbounds for i in eachindex(v)[2 : end]
         x = v[i]

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -6,6 +6,23 @@ using StaticArrays: @SVector
 using Parametron
 using Parametron.Functions
 
+@testset "canonicalize" begin
+    x = Variable(1)
+    y = Variable(2)
+
+    @test canonicalize(3 * x * y) === canonicalize(3 * y * x) == QuadraticTerm(3, x, y)
+    @test canonicalize(y + x - 2 * y + 3) == x - y + 3
+    @test canonicalize(x * y + y * x + y + y + x - y + 4) == 2 * x * y + x + y + 4
+
+    f = x * y + y * x + y + y + x - y + 4
+    global allocs
+    for i = 1 : 2
+        fcopy = QuadraticFunction(f)
+        allocs = @allocated canonicalize!(fcopy)
+    end
+    @test allocs == 0
+end
+
 @testset "LinearTerm" begin
     x = Variable(1)
     @test LinearTerm(4.5, x) === 4.5 * x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 module ParametronTest
 
+include("util.jl")
 include("parameter.jl")
 include("functions.jl")
 include("lazyexpression.jl")

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,0 +1,27 @@
+module UtilTest
+
+using Parametron
+using Test
+
+using Parametron: sort_and_combine!
+using Base.Sort: QuickSort
+
+combinepair(x, y) = first(x) => last(x) + last(y)
+
+@testset "sort_and_combine!" begin
+    n = 100
+    @test sort_and_combine!([2 => 1.0, 2 => 2.0]; combine=combinepair, by=first) == [2 => 3.0]
+    @test sort_and_combine!([3 => 1.0, 2 => 4.0, 3 => 2.0, 1 => 2.0], combine=combinepair, by=first) == [1 => 2.0, 2 => 4.0, 3 => 3.0]
+    @test length(sort_and_combine!(Pair.(1 : n, rand(n)), combine=combinepair, by=first)) == n
+    @test length(sort_and_combine!(Pair.(fill(3, n), rand(n)), combine=combinepair, by=first)) == 1
+
+    v = [rand(1 : round(Int, n / 2)) => rand() for i = 1 : n]
+    global allocs
+    for i = 1 : 2
+        vcopy = copy(v)
+        allocs = @allocated sort_and_combine!(vcopy; combine=combinepair, by=first, alg=QuickSort)
+    end
+    @test allocs == 0
+end
+
+end # module


### PR DESCRIPTION
Used to re-express `Parametron.Functions` types in a standard form. Useful for easy comparison, among other things.

CC: @timholy. Decided against overloading `==` and `hash`, and remembered that @rdeits and I had implemented something similar for `MathOptInterface` functions.