### PR TITLE
Add support for quadratic constraints

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -72,19 +72,23 @@ function add_constraint(m::Model, constraint::Constraint)
     nothing
 end
 
-_add_nonnegative_constraint!(m::Model{T}, expr, val::AffineFunction) where {T} =
-    add_constraint(m, Constraint(T, expr, MOI.GreaterThan(zero(T))))
-_add_nonpositive_constraint!(m::Model{T}, expr, val::AffineFunction) where {T} =
-    add_constraint(m, Constraint(T, expr, MOI.LessThan(zero(T))))
-_add_zero_constraint!(m::Model{T}, expr, val::AffineFunction) where {T} =
-    add_constraint(m, Constraint(T, expr, MOI.EqualTo(zero(T))))
+for F in (:AffineFunction, QuadraticFunction)
+    @eval begin
+        _add_nonnegative_constraint!(m::Model{T}, expr, val::$F) where {T} =
+            add_constraint(m, Constraint(T, expr, MOI.GreaterThan(zero(T))))
+        _add_nonpositive_constraint!(m::Model{T}, expr, val::$F) where {T} =
+            add_constraint(m, Constraint(T, expr, MOI.LessThan(zero(T))))
+        _add_zero_constraint!(m::Model{T}, expr, val::$F) where {T} =
+            add_constraint(m, Constraint(T, expr, MOI.EqualTo(zero(T))))
 
-_add_nonnegative_constraint!(m::Model{T}, expr, val::AbstractVector{<:AffineFunction}) where {T} =
-    add_constraint(m, Constraint(T, expr, MOI.Nonnegatives(length(val))))
-_add_nonpositive_constraint!(m::Model{T}, expr, val::AbstractVector{<:AffineFunction}) where {T} =
-    add_constraint(m, Constraint(T, expr, MOI.Nonpositives(length(val))))
-_add_zero_constraint!(m::Model{T}, expr, val::AbstractVector{<:AffineFunction}) where {T} =
-    add_constraint(m, Constraint(T, expr, MOI.Zeros(length(val))))
+        _add_nonnegative_constraint!(m::Model{T}, expr, val::AbstractVector{<:$F}) where {T} =
+            add_constraint(m, Constraint(T, expr, MOI.Nonnegatives(length(val))))
+        _add_nonpositive_constraint!(m::Model{T}, expr, val::AbstractVector{<:$F}) where {T} =
+            add_constraint(m, Constraint(T, expr, MOI.Nonpositives(length(val))))
+        _add_zero_constraint!(m::Model{T}, expr, val::AbstractVector{<:$F}) where {T} =
+            add_constraint(m, Constraint(T, expr, MOI.Zeros(length(val))))
+    end
+end
 
 add_nonnegative_constraint!(m::Model, expr) = _add_nonnegative_constraint!(m, expr, evalarg(expr))
 add_nonpositive_constraint!(m::Model, expr) = _add_nonpositive_constraint!(m, expr, evalarg(expr))

--- a/src/moi_interop.jl
+++ b/src/moi_interop.jl
@@ -5,7 +5,7 @@ MOIU.@model(ParametronMOIModel, # modelname
     (MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives), # vectorsets
     (), # typedvectorsets
     (MOI.SingleVariable,), # scalarfunctions
-    (MOI.ScalarAffineFunction,), # typedscalarfunctions
+    (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction), # typedscalarfunctions
     (), # vectorfunctions
     (MOI.VectorAffineFunction,) # typedvectorfunctions
 )
@@ -105,6 +105,7 @@ canonical_function_type(::Type{<:QuadraticFunction}, ::Type{T}) where {T} = Quad
 moi_to_native_type(::Type{MOI.ScalarAffineFunction}) = AffineFunction{T} where T
 moi_to_native_type(::Type{MOI.ScalarQuadraticFunction}) = QuadraticFunction{T} where T
 moi_to_native_type(::Type{MOI.VectorAffineFunction}) = Vector{AffineFunction{T}} where T
+moi_to_native_type(::Type{MOI.VectorQuadraticFunction}) = Vector{QuadraticFunction{T}} where T
 moi_to_native_type(::Type{MOI.SingleVariable}) = Nothing
 
 
@@ -182,6 +183,12 @@ let
                         (MOI.VectorAffineFunction{T} where T, MOI.Nonnegatives),
                         (MOI.VectorAffineFunction{T} where T, MOI.Nonpositives),
                         (MOI.VectorAffineFunction{T} where T, MOI.Zeros),
+                        (MOI.ScalarQuadraticFunction{T} where T, MOI.GreaterThan{T} where T),
+                        (MOI.ScalarQuadraticFunction{T} where T, MOI.LessThan{T} where T),
+                        (MOI.ScalarQuadraticFunction{T} where T, MOI.EqualTo{T} where T),
+                        (MOI.VectorQuadraticFunction{T} where T, MOI.Nonnegatives),
+                        (MOI.VectorQuadraticFunction{T} where T, MOI.Nonpositives),
+                        (MOI.VectorQuadraticFunction{T} where T, MOI.Zeros),
                         (MOI.SingleVariable, MOI.Integer),
                         (MOI.SingleVariable, MOI.ZeroOne)]
     fieldnames = Symbol[]


### PR DESCRIPTION
Unfortunately, I don't think there are currently any MOI optimizers that support modification of quadratic constraints (as I found out after making these changes). 

Still useful sans function modification though.